### PR TITLE
[dev] remove deprecated PROGRAM-ID which was removed in protocol 6 from EXT-X-STREAM-INF.

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -432,12 +432,11 @@ ngx_rtmp_hls_write_variant_playlist(ngx_rtmp_session_t *s)
         p = buffer;
         last = buffer + sizeof(buffer);
 
-        /* TODO: PROGRAM-ID was removed in protocol version 6 */
-        p = ngx_slprintf(p, last, "#EXT-X-STREAM-INF:PROGRAM-ID=1");
-
+        p = ngx_slprintf(p, last, "#EXT-X-STREAM-INF:");
+        
         arg = var->args.elts;
         for (k = 0; k < var->args.nelts; k++, arg++) {
-            p = ngx_slprintf(p, last, ",%V", arg);
+            p = (k == 0 ? ngx_slprintf(p, last, "%V", arg) : ngx_slprintf(p, last, ",%V", arg));
         }
 
         if (p < last) {


### PR DESCRIPTION
[draft-pantos-http-live-streaming-17](https://tools.ietf.org/html/draft-pantos-http-live-streaming-17#page-22)
![image](https://user-images.githubusercontent.com/26999792/53646901-51a42f00-3c77-11e9-993e-a27b949bf598.png)
