### PR TITLE
[fix] fix a bug which will cause compiling error and json parse error when ifdef NGX_RTMP_POOL_DEBUG.

### DIFF
--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -36,7 +36,6 @@ static time_t                       start_time;
 #define NGX_RTMP_STAT_FORMAT_XML    0x01
 #define NGX_RTMP_STAT_FORMAT_JSON   0x02
 
-#define NGX_RTMP_POOL_DEBUG         0x01
 
 /*
  * global: stat-{bufs-{total,free,used}, total bytes in/out, bw in/out} - cscf
@@ -1053,7 +1052,7 @@ ngx_rtmp_stat_server(ngx_http_request_t *r, ngx_chain_t ***lll,
     if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<server>\r\n");
     }
-    
+
 #ifdef NGX_RTMP_POOL_DEBUG
     ngx_rtmp_stat_dump_pool(slcf, r, lll, cscf->pool);
     if (slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -344,12 +344,14 @@ ngx_rtmp_stat_get_pool_size(ngx_pool_t *pool, ngx_uint_t *nlarge,
 
 
 static void
-ngx_rtmp_stat_dump_pool(ngx_rtmp_stat_loc_conf_t *slcf,
-        ngx_http_request_t *r, ngx_chain_t ***lll,
+ngx_rtmp_stat_dump_pool(ngx_http_request_t *r, ngx_chain_t ***lll,
         ngx_pool_t *pool)
 {
-    ngx_uint_t  nlarge, size;
-    u_char      buf[NGX_INT_T_LEN];
+    ngx_uint_t                      nlarge, size;
+    u_char                          buf[NGX_INT_T_LEN];
+    ngx_rtmp_stat_loc_conf_t       *slcf;
+    
+    slcf = ngx_http_get_module_loc_conf(r, ngx_rtmp_stat_module);
 
     size = 0;
     nlarge = 0;
@@ -381,7 +383,7 @@ ngx_rtmp_stat_client(ngx_http_request_t *r, ngx_chain_t ***lll,
     slcf = ngx_http_get_module_loc_conf(r, ngx_rtmp_stat_module);
 
 #ifdef NGX_RTMP_POOL_DEBUG
-    ngx_rtmp_stat_dump_pool(slcf, r, lll, s->connection->pool);
+    ngx_rtmp_stat_dump_pool(r, lll, s->connection->pool);
     if(slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
         NGX_RTMP_STAT_L(",");
     }
@@ -1054,7 +1056,7 @@ ngx_rtmp_stat_server(ngx_http_request_t *r, ngx_chain_t ***lll,
     }
 
 #ifdef NGX_RTMP_POOL_DEBUG
-    ngx_rtmp_stat_dump_pool(slcf, r, lll, cscf->pool);
+    ngx_rtmp_stat_dump_pool(r, lll, cscf->pool);
     if (slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
         NGX_RTMP_STAT_L(",");
     }


### PR DESCRIPTION
I've not been paying attention to the case when **NGX_RTMP_POOL_DEBUG** is defined for a long time. Until now, I have realized it will cause some serious compiling and parsing problem and fixed them.
After this fix, the JSON struct performed some little changes.

- `http-flv.servers` -> `http-flv.server`
- `http-flv.server` -> 
```js
{
    pool: {}, // ifdef NGX_RTMP_POOL_DEBUG 
    applications: []
}
```
- `http-flv.server.applications[i].live.streams[i].clients[i]` added a new key-value named `pool` (ifdef **NGX_RTMP_POOL_DEBUG**)

![image](https://user-images.githubusercontent.com/26999792/53684946-ff364180-3d4e-11e9-8e92-0925df15c3ca.png)
