### PR TITLE
[fix] fix a stream stat loop bug

### DIFF
--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -283,7 +283,7 @@ ngx_rtmp_stat_bw(ngx_http_request_t *r, ngx_chain_t ***lll,
     ngx_rtmp_update_bandwidth(bw, 0);
 
     if (flags & NGX_RTMP_STAT_BW) {
-        if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+        if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
             NGX_RTMP_STAT_L("<bw_");
             NGX_RTMP_STAT_CS(name);
             NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), ">%uL</bw_",
@@ -301,7 +301,7 @@ ngx_rtmp_stat_bw(ngx_http_request_t *r, ngx_chain_t ***lll,
     }
 
     if (flags & NGX_RTMP_STAT_BYTES) {
-        if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+        if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
             NGX_RTMP_STAT_L("<bytes_");
             NGX_RTMP_STAT_CS(name);
             NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), ">%uL</bytes_",
@@ -356,7 +356,7 @@ ngx_rtmp_stat_dump_pool(ngx_http_request_t *r, ngx_chain_t ***lll,
     size = 0;
     nlarge = 0;
     ngx_rtmp_stat_get_pool_size(pool, &nlarge, &size);
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<pool><nlarge>");
         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), "%ui", nlarge) - buf);
         NGX_RTMP_STAT_L("</nlarge><size>");
@@ -384,12 +384,12 @@ ngx_rtmp_stat_client(ngx_http_request_t *r, ngx_chain_t ***lll,
 
 #ifdef NGX_RTMP_POOL_DEBUG
     ngx_rtmp_stat_dump_pool(r, lll, s->connection->pool);
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
         NGX_RTMP_STAT_L(",");
     }
 #endif
 
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<id>");
         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), "%ui",
                       (ngx_uint_t) s->connection->number) - buf);
@@ -517,7 +517,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
 
     slcf = ngx_http_get_module_loc_conf(r, ngx_rtmp_stat_module);
 
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<live>\r\n");
     } else {
         NGX_RTMP_STAT_L("\"live\":{");
@@ -526,19 +526,19 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
 
     total_nclients = 0;
     for (n = 0; n < lacf->nbuckets; ++n) {
-        for (stream = lacf->streams[n]; stream; stream = stream->next) {
-            
-            if(total_nclients > 0) {
-                NGX_RTMP_STAT_L(",");
+        for (stream = lacf->streams[n]; ; stream = stream->next) {
+
+            if (!stream) {
+                break;
             }
             
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<stream>\r\n");
             } else {
                 NGX_RTMP_STAT_L("{");
             }
 
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<name>");
                 NGX_RTMP_STAT_ECS(stream->name);
                 NGX_RTMP_STAT_L("</name>\r\n");
@@ -650,7 +650,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                        NGX_RTMP_STAT_L("</client>\r\n");
                     } else {
                         NGX_RTMP_STAT_L("}");
-                        if(ctx->next) {
+                        if (ctx->next) {
                             NGX_RTMP_STAT_L(",");
                         }
                     }
@@ -666,7 +666,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
             }
             
             if (codec) {
-                if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+                if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                     NGX_RTMP_STAT_L("<meta>");
 
                     NGX_RTMP_STAT_L("<video>");
@@ -790,7 +790,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT_ECS(cname);
                     }
                     if (codec->aac_profile) {
-                        if(f == 1) NGX_RTMP_STAT_L("\",");
+                        if (f == 1) NGX_RTMP_STAT_L("\",");
                         f = 2;
                         NGX_RTMP_STAT_L("\"profile\":\"");
                         NGX_RTMP_STAT_CS(
@@ -799,20 +799,20 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                                                               codec->aac_ps));
                     }
                     if (codec->aac_chan_conf) {
-                        if(f >= 1) NGX_RTMP_STAT_L("\",");
+                        if (f >= 1) NGX_RTMP_STAT_L("\",");
                         f = 3;
                         NGX_RTMP_STAT_L("\"channels\":\"");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%ui", codec->aac_chan_conf) - buf);
                     } else if (codec->audio_channels) {
-                        if(f >= 1) NGX_RTMP_STAT_L("\",");
+                        if (f >= 1) NGX_RTMP_STAT_L("\",");
                         f = 3;
                         NGX_RTMP_STAT_L("\"channels\":\"");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%ui", codec->audio_channels) - buf);
                     }
                     if (codec->sample_rate) {
-                        if(f >= 1) NGX_RTMP_STAT_L("\",");
+                        if (f >= 1) NGX_RTMP_STAT_L("\",");
                         f = 4;
                         NGX_RTMP_STAT_L("\"sample_rate\":");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
@@ -827,7 +827,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                 }
             }
             
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<nclients>");
                 NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                               "%ui", nclients) - buf);
@@ -843,7 +843,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
 
                 NGX_RTMP_STAT_L("</stream>\r\n");
             } else {
-                if(codec) {
+                if (codec) {
                     NGX_RTMP_STAT_L(",");
                 }
                 NGX_RTMP_STAT_L("\"nclients\":");
@@ -866,10 +866,12 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
 
                 NGX_RTMP_STAT_L("}");
             }
+
+            NGX_RTMP_STAT_L(",");
         }
     }
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<nclients>");
         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                       "%ui", total_nclients) - buf);
@@ -902,7 +904,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
 
     slcf = ngx_http_get_module_loc_conf(r, ngx_rtmp_stat_module);
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<play>\r\n");
     } else {
         NGX_RTMP_STAT_L("\"play\":{");
@@ -913,7 +915,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
     for (n = 0; n < pacf->nbuckets; ++n) {
         for (ctx = pacf->ctx[n]; ctx; ) {
             
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<stream>\r\n");
                 NGX_RTMP_STAT_L("<name>");
                 NGX_RTMP_STAT_ECS(ctx->name);
@@ -936,7 +938,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
 
                 s = ctx->session;
                 if (slcf->stat & NGX_RTMP_STAT_CLIENTS) {
-                    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+                    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                         NGX_RTMP_STAT_L("<client>");
 
                         ngx_rtmp_stat_client(r, lll, s);
@@ -957,14 +959,14 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
                                       "%D", s->current_time) - bbuf);
                         
                         NGX_RTMP_STAT_L("}");
-                        if(ctx->next) {
+                        if (ctx->next) {
                             NGX_RTMP_STAT_L(",");
                         }
                     }
                 }
             }
             total_nclients += nclients;
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<active/>");
                 NGX_RTMP_STAT_L("<nclients>");
                 NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
@@ -983,7 +985,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
         }
     }
 
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<nclients>");
         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                       "%ui", total_nclients) - buf);
@@ -1006,7 +1008,7 @@ ngx_rtmp_stat_application(ngx_http_request_t *r, ngx_chain_t ***lll,
     
     slcf = ngx_http_get_module_loc_conf(r, ngx_rtmp_stat_module);
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<application>\r\n");
         NGX_RTMP_STAT_L("<name>");
         NGX_RTMP_STAT_ES(&cacf->name);
@@ -1033,7 +1035,7 @@ ngx_rtmp_stat_application(ngx_http_request_t *r, ngx_chain_t ***lll,
                 cacf->app_conf[ngx_rtmp_play_module.ctx_index]);
     }
 
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("</application>\r\n");
     } else {
         NGX_RTMP_STAT_L("}");
@@ -1190,19 +1192,19 @@ ngx_rtmp_stat_handler(ngx_http_request_t *r)
     ngx_rtmp_stat_bw(r, lll, &ngx_rtmp_bw_in, "in", NGX_RTMP_STAT_BW_BYTES);
     ngx_rtmp_stat_bw(r, lll, &ngx_rtmp_bw_out, "out", NGX_RTMP_STAT_BW_BYTES);
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
         NGX_RTMP_STAT_L("\"server\":{");
     }
 
     cscf = cmcf->servers.elts;
     for (n = 0; n < cmcf->servers.nelts; ++n, ++cscf) {
         ngx_rtmp_stat_server(r, lll, *cscf);
-        if(slcf->format & NGX_RTMP_STAT_FORMAT_JSON && n < cmcf->servers.nelts-1) {
+        if (slcf->format & NGX_RTMP_STAT_FORMAT_JSON && n < cmcf->servers.nelts-1) {
             NGX_RTMP_STAT_L(",");
         }
     }
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("</http-flv>\r\n");
     } else {
         NGX_RTMP_STAT_L("}}}");
@@ -1213,7 +1215,7 @@ ngx_rtmp_stat_handler(ngx_http_request_t *r)
         len += (l->buf->last - l->buf->pos);
     }
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         ngx_str_set(&r->headers_out.content_type, "text/xml");
     } else {
         ngx_str_set(&r->headers_out.content_type, "application/json");


### PR DESCRIPTION
At the first beginning, I used `total_nclients` to decide whether there are more streams or not, but it's wrong. If a stream has no clients and this live application has more streams, the JSON string generated finally will miss a comma, which leads a serious error. I have tried to fix it.
And, I have fixed some code flaws in order to keep up with original author's code style.