### PR TITLE
 [fix] fix play and live stat bug when total_nclients is zero.

### DIFF
--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -507,6 +507,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
     ngx_int_t                       n;
     ngx_uint_t                      nclients, total_nclients;
     ngx_uint_t                      f;
+    ngx_flag_t                      prev;
     u_char                          buf[NGX_INT_T_LEN];
     u_char                          bbuf[NGX_INT32_LEN];
     ngx_rtmp_stat_loc_conf_t       *slcf;
@@ -526,12 +527,13 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
     }
 
     total_nclients = 0;
+    prev = 0;
     for (n = 0; n < lacf->nbuckets; ++n) {
         for (stream = lacf->streams[n]; stream; stream = stream->next) {
             if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<stream>\r\n");
             } else {
-                if (total_nclients || stream->next) {
+                if (prev) {
                     NGX_RTMP_STAT_L(",");
                 }
 
@@ -861,6 +863,8 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                 }
 
                 NGX_RTMP_STAT_L("}");
+
+                prev = 1;
             }
         }
     }
@@ -887,6 +891,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
     ngx_rtmp_play_ctx_t            *ctx, *sctx;
     ngx_rtmp_session_t             *s;
     ngx_uint_t                      n, nclients, total_nclients;
+    ngx_flag_t                      prev;
     u_char                          buf[NGX_INT_T_LEN];
     u_char                          bbuf[NGX_INT32_LEN];
     ngx_rtmp_stat_loc_conf_t       *slcf;
@@ -905,6 +910,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
     }
 
     total_nclients = 0;
+    prev = 0;
     for (n = 0; n < pacf->nbuckets; ++n) {
         for (ctx = pacf->ctx[n]; ctx; ) {
             if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
@@ -913,7 +919,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
                 NGX_RTMP_STAT_ECS(ctx->name);
                 NGX_RTMP_STAT_L("</name>\r\n");
             } else {
-                if (total_nclients || ctx->next) {
+                if (prev) {
                     NGX_RTMP_STAT_L(",");
                 }
 
@@ -973,6 +979,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
                 NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                               "%ui", nclients) - buf);
                 NGX_RTMP_STAT_L("}");
+                prev = 1;
             }
         }
     }

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -283,7 +283,7 @@ ngx_rtmp_stat_bw(ngx_http_request_t *r, ngx_chain_t ***lll,
     ngx_rtmp_update_bandwidth(bw, 0);
 
     if (flags & NGX_RTMP_STAT_BW) {
-        if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+        if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
             NGX_RTMP_STAT_L("<bw_");
             NGX_RTMP_STAT_CS(name);
             NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), ">%uL</bw_",
@@ -301,7 +301,7 @@ ngx_rtmp_stat_bw(ngx_http_request_t *r, ngx_chain_t ***lll,
     }
 
     if (flags & NGX_RTMP_STAT_BYTES) {
-        if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+        if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
             NGX_RTMP_STAT_L("<bytes_");
             NGX_RTMP_STAT_CS(name);
             NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), ">%uL</bytes_",
@@ -356,7 +356,7 @@ ngx_rtmp_stat_dump_pool(ngx_http_request_t *r, ngx_chain_t ***lll,
     size = 0;
     nlarge = 0;
     ngx_rtmp_stat_get_pool_size(pool, &nlarge, &size);
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<pool><nlarge>");
         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), "%ui", nlarge) - buf);
         NGX_RTMP_STAT_L("</nlarge><size>");
@@ -384,12 +384,12 @@ ngx_rtmp_stat_client(ngx_http_request_t *r, ngx_chain_t ***lll,
 
 #ifdef NGX_RTMP_POOL_DEBUG
     ngx_rtmp_stat_dump_pool(r, lll, s->connection->pool);
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
         NGX_RTMP_STAT_L(",");
     }
 #endif
 
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<id>");
         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), "%ui",
                       (ngx_uint_t) s->connection->number) - buf);
@@ -517,7 +517,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
 
     slcf = ngx_http_get_module_loc_conf(r, ngx_rtmp_stat_module);
 
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<live>\r\n");
     } else {
         NGX_RTMP_STAT_L("\"live\":{");
@@ -526,19 +526,19 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
 
     total_nclients = 0;
     for (n = 0; n < lacf->nbuckets; ++n) {
-        for (stream = lacf->streams[n]; stream; stream = stream->next) {
-            
-            if(total_nclients > 0) {
-                NGX_RTMP_STAT_L(",");
+        for (stream = lacf->streams[n]; ; stream = stream->next) {
+
+            if (!stream) {
+                break;
             }
             
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<stream>\r\n");
             } else {
                 NGX_RTMP_STAT_L("{");
             }
 
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<name>");
                 NGX_RTMP_STAT_ECS(stream->name);
                 NGX_RTMP_STAT_L("</name>\r\n");
@@ -650,7 +650,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                        NGX_RTMP_STAT_L("</client>\r\n");
                     } else {
                         NGX_RTMP_STAT_L("}");
-                        if(ctx->next) {
+                        if (ctx->next) {
                             NGX_RTMP_STAT_L(",");
                         }
                     }
@@ -666,7 +666,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
             }
             
             if (codec) {
-                if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+                if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                     NGX_RTMP_STAT_L("<meta>");
 
                     NGX_RTMP_STAT_L("<video>");
@@ -790,7 +790,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT_ECS(cname);
                     }
                     if (codec->aac_profile) {
-                        if(f == 1) NGX_RTMP_STAT_L("\",");
+                        if (f == 1) NGX_RTMP_STAT_L("\",");
                         f = 2;
                         NGX_RTMP_STAT_L("\"profile\":\"");
                         NGX_RTMP_STAT_CS(
@@ -799,20 +799,20 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                                                               codec->aac_ps));
                     }
                     if (codec->aac_chan_conf) {
-                        if(f >= 1) NGX_RTMP_STAT_L("\",");
+                        if (f >= 1) NGX_RTMP_STAT_L("\",");
                         f = 3;
                         NGX_RTMP_STAT_L("\"channels\":\"");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%ui", codec->aac_chan_conf) - buf);
                     } else if (codec->audio_channels) {
-                        if(f >= 1) NGX_RTMP_STAT_L("\",");
+                        if (f >= 1) NGX_RTMP_STAT_L("\",");
                         f = 3;
                         NGX_RTMP_STAT_L("\"channels\":\"");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%ui", codec->audio_channels) - buf);
                     }
                     if (codec->sample_rate) {
-                        if(f >= 1) NGX_RTMP_STAT_L("\",");
+                        if (f >= 1) NGX_RTMP_STAT_L("\",");
                         f = 4;
                         NGX_RTMP_STAT_L("\"sample_rate\":");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
@@ -827,7 +827,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                 }
             }
             
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<nclients>");
                 NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                               "%ui", nclients) - buf);
@@ -843,7 +843,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
 
                 NGX_RTMP_STAT_L("</stream>\r\n");
             } else {
-                if(codec) {
+                if (codec) {
                     NGX_RTMP_STAT_L(",");
                 }
                 NGX_RTMP_STAT_L("\"nclients\":");
@@ -866,10 +866,12 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
 
                 NGX_RTMP_STAT_L("}");
             }
+
+            NGX_RTMP_STAT_L(",");
         }
     }
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<nclients>");
         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                       "%ui", total_nclients) - buf);
@@ -902,7 +904,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
 
     slcf = ngx_http_get_module_loc_conf(r, ngx_rtmp_stat_module);
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<play>\r\n");
     } else {
         NGX_RTMP_STAT_L("\"play\":{");
@@ -913,7 +915,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
     for (n = 0; n < pacf->nbuckets; ++n) {
         for (ctx = pacf->ctx[n]; ctx; ) {
             
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<stream>\r\n");
                 NGX_RTMP_STAT_L("<name>");
                 NGX_RTMP_STAT_ECS(ctx->name);
@@ -936,7 +938,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
 
                 s = ctx->session;
                 if (slcf->stat & NGX_RTMP_STAT_CLIENTS) {
-                    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+                    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                         NGX_RTMP_STAT_L("<client>");
 
                         ngx_rtmp_stat_client(r, lll, s);
@@ -957,14 +959,14 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
                                       "%D", s->current_time) - bbuf);
                         
                         NGX_RTMP_STAT_L("}");
-                        if(ctx->next) {
+                        if (ctx->next) {
                             NGX_RTMP_STAT_L(",");
                         }
                     }
                 }
             }
             total_nclients += nclients;
-            if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+            if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
                 NGX_RTMP_STAT_L("<active/>");
                 NGX_RTMP_STAT_L("<nclients>");
                 NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
@@ -983,7 +985,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
         }
     }
 
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<nclients>");
         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                       "%ui", total_nclients) - buf);
@@ -1006,7 +1008,7 @@ ngx_rtmp_stat_application(ngx_http_request_t *r, ngx_chain_t ***lll,
     
     slcf = ngx_http_get_module_loc_conf(r, ngx_rtmp_stat_module);
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<application>\r\n");
         NGX_RTMP_STAT_L("<name>");
         NGX_RTMP_STAT_ES(&cacf->name);
@@ -1033,7 +1035,7 @@ ngx_rtmp_stat_application(ngx_http_request_t *r, ngx_chain_t ***lll,
                 cacf->app_conf[ngx_rtmp_play_module.ctx_index]);
     }
 
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("</application>\r\n");
     } else {
         NGX_RTMP_STAT_L("}");
@@ -1190,19 +1192,19 @@ ngx_rtmp_stat_handler(ngx_http_request_t *r)
     ngx_rtmp_stat_bw(r, lll, &ngx_rtmp_bw_in, "in", NGX_RTMP_STAT_BW_BYTES);
     ngx_rtmp_stat_bw(r, lll, &ngx_rtmp_bw_out, "out", NGX_RTMP_STAT_BW_BYTES);
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_JSON) {
         NGX_RTMP_STAT_L("\"server\":{");
     }
 
     cscf = cmcf->servers.elts;
     for (n = 0; n < cmcf->servers.nelts; ++n, ++cscf) {
         ngx_rtmp_stat_server(r, lll, *cscf);
-        if(slcf->format & NGX_RTMP_STAT_FORMAT_JSON && n < cmcf->servers.nelts-1) {
+        if (slcf->format & NGX_RTMP_STAT_FORMAT_JSON && n < cmcf->servers.nelts-1) {
             NGX_RTMP_STAT_L(",");
         }
     }
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("</http-flv>\r\n");
     } else {
         NGX_RTMP_STAT_L("}}}");
@@ -1213,7 +1215,7 @@ ngx_rtmp_stat_handler(ngx_http_request_t *r)
         len += (l->buf->last - l->buf->pos);
     }
     
-    if(slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
+    if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         ngx_str_set(&r->headers_out.content_type, "text/xml");
     } else {
         ngx_str_set(&r->headers_out.content_type, "application/json");

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -521,7 +521,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
     if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<live>\r\n");
     } else {
-        NGX_RTMP_STAT_L("\"live\":{");
+        NGX_RTMP_STAT_L(",\"live\":{");
         NGX_RTMP_STAT_L("\"streams\":[");
     }
 
@@ -769,19 +769,17 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT_L("\"");
                     }
                     if (codec->avc_compat) {
-                        NGX_RTMP_STAT_L(",\"compat\":\"");
+                        NGX_RTMP_STAT_L(",\"compat\":");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%ui", codec->avc_compat) - buf);
-                        NGX_RTMP_STAT_L("\"");
                     }
                     if (codec->avc_level) {
-                        NGX_RTMP_STAT_L(",\"level\":\"");
+                        NGX_RTMP_STAT_L(",\"level\":");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%.1f", codec->avc_level / 10.) - buf);
-                        NGX_RTMP_STAT_L("\"");
                     }
 
-                    NGX_RTMP_STAT_L("},\"audio\": {");
+                    NGX_RTMP_STAT_L("},\"audio\":{");
                     cname = ngx_rtmp_get_audio_codec_name(codec->audio_codec_id);
                     f = 0;
                     if (*cname) {
@@ -801,18 +799,18 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                     if (codec->aac_chan_conf) {
                         if (f >= 1) NGX_RTMP_STAT_L("\",");
                         f = 3;
-                        NGX_RTMP_STAT_L("\"channels\":\"");
+                        NGX_RTMP_STAT_L("\"channels\":");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%ui", codec->aac_chan_conf) - buf);
                     } else if (codec->audio_channels) {
-                        if (f >= 1) NGX_RTMP_STAT_L("\",");
+                        if (f >= 1) NGX_RTMP_STAT_L(",");
                         f = 3;
-                        NGX_RTMP_STAT_L("\"channels\":\"");
+                        NGX_RTMP_STAT_L("\"channels\":");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%ui", codec->audio_channels) - buf);
                     }
                     if (codec->sample_rate) {
-                        if (f >= 1) NGX_RTMP_STAT_L("\",");
+                        if (f >= 1) NGX_RTMP_STAT_L(",");
                         f = 4;
                         NGX_RTMP_STAT_L("\"sample_rate\":");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
@@ -821,9 +819,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                     if (f >= 1 && f <= 3) {
                         NGX_RTMP_STAT_L("\"");
                     }
-                    NGX_RTMP_STAT_L("}");
-
-                    NGX_RTMP_STAT_L("}");
+                    NGX_RTMP_STAT_L("}}");
                 }
             }
 
@@ -904,7 +900,7 @@ ngx_rtmp_stat_play(ngx_http_request_t *r, ngx_chain_t ***lll,
     if (slcf->format & NGX_RTMP_STAT_FORMAT_XML) {
         NGX_RTMP_STAT_L("<play>\r\n");
     } else {
-        NGX_RTMP_STAT_L("\"play\":{");
+        NGX_RTMP_STAT_L(",\"play\":{");
         NGX_RTMP_STAT_L("\"streams\":[");
     }
 
@@ -1013,12 +1009,7 @@ ngx_rtmp_stat_application(ngx_http_request_t *r, ngx_chain_t ***lll,
         NGX_RTMP_STAT_L("{");
         NGX_RTMP_STAT_L("\"name\":\"");
         NGX_RTMP_STAT_ES(&cacf->name);
-
-        if (slcf->stat & NGX_RTMP_STAT_LIVE || slcf->stat & NGX_RTMP_STAT_PLAY) {
-            NGX_RTMP_STAT_L("\",");
-        } else {
-            NGX_RTMP_STAT_L("\"");
-        }
+		NGX_RTMP_STAT_L("\"");
     }
 
     if (slcf->stat & NGX_RTMP_STAT_LIVE) {


### PR DESCRIPTION
I cannot reproduce the case below, so I just have tried to fix play and live stat bug when total_nclients is zero. Check and test it carefully please.
Error case:
```json
{
	"http-flv": {
		"nginx_version": "1.12.2",
		"nginx_http_flv_version": "1.2.6",
		"compiler": "cl 19.13",
		"built": "Mar 15 2019 19:13:20",
		"pid": 11764,
		"uptime": 431483,
		"naccepted": 351,
		"bw_in": 0,
		"bytes_in": 15144154714,
		"bw_out": 0,
		"bytes_out": 15000743868,
		"servers": [{
			"applications": [{
				"name": "live",
				"live": {
					"streams": [{
						"name": "13713500022@channel_1",
						"time": 4537565,
						"bw_in": 0,
						"bytes_in": 0,
						"bw_out": 0,
						"bytes_out": 0,
						"bw_audio": 0,
						"bw_video": 0,
						"clients": [],
						"nclients": 0,
						"publishing": false,
						"active": false
					} {
						"name": "13713500022@channel_2",
						"time": 4537564,
						"bw_in": 0,
						"bytes_in": 0,
						"bw_out": 0,
						"bytes_out": 0,
						"bw_audio": 0,
						"bw_video": 0,
						"clients": [],
						"nclients": 0,
						"publishing": false,
						"active": false
					} {
						"name": "13713500022@channel_3",
						"time": 4537561,
						"bw_in": 0,
						"bytes_in": 0,
						"bw_out": 0,
						"bytes_out": 0,
						"bw_audio": 0,
						"bw_video": 0,
						"clients": [],
						"nclients": 0,
						"publishing": false,
						"active": false
					} {
						"name": "13713500022@channel_4",
						"time": 62929406,
						"bw_in": 0,
						"bytes_in": 0,
						"bw_out": 0,
						"bytes_out": 0,
						"bw_audio": 0,
						"bw_video": 0,
						"clients": [],
						"nclients": 0,
						"publishing": false,
						"active": false
					}],
					"nclients": 0
				}
			}, {
				"name": "test",
				"live": {
					"streams": [],
					"nclients": 0
				}
			}]
		}]
	}
}
```