### PR TITLE
Fixes issue in Nginx HLS Encryption Keys

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -2347,7 +2347,7 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_str_value(conf->base_url, prev->base_url, "");
     ngx_conf_merge_value(conf->granularity, prev->granularity, 0);
     ngx_conf_merge_value(conf->keys, prev->keys, 0);
-    ngx_conf_merge_str_value(conf->key_path, prev->key_path, "");
+    /*ngx_conf_merge_str_value(conf->key_path, prev->key_path, "");*/
     ngx_conf_merge_str_value(conf->key_url, prev->key_url, "");
     ngx_conf_merge_uint_value(conf->frags_per_key, prev->frags_per_key, 0);
 


### PR DESCRIPTION
This is a fix for the issue identified in the [PR #1158 for arut/nginx-rtmp-module](https://github.com/arut/nginx-rtmp-module/pull/1158) regarding HLS Encryption causing a hard crash with the below error which exists in nginx-http-flv-module.
```
nginx: [emerg] the same path name "/data/hlskeys" used in /usr/local/nginx/conf/nginx.conf:178 and in /usr/local/nginx/conf/nginx.conf:178
```

Commenting of line 2350 in hls/ngx_rtmp_hls_module.c corrects the problem and allows Nginx to start properly and use HLS encryption
